### PR TITLE
Don't mark derived queries with groups as cross joins.

### DIFF
--- a/sqlcop/checks/cross_join.py
+++ b/sqlcop/checks/cross_join.py
@@ -19,6 +19,7 @@ class CrossJoinCheck(object):
             # Yes if you have the same table name in multiple databases
             # you'll have a bad time here
             tables.update(metadata.tables)
+
         return tables
 
     def __call__(self, stmt):
@@ -36,6 +37,7 @@ class CrossJoinCheck(object):
             if (isinstance(tok, sqlparse.sql.Where) or
                     tok.match(sqlparse.tokens.Keyword.DML, 'SELECT') or
                     tok.match(sqlparse.tokens.Keyword, 'INNER JOIN') or
+                    tok.match(sqlparse.tokens.Keyword, 'GROUP') or
                     tok.match(sqlparse.tokens.Keyword, 'LEFT OUTER JOIN')):
                 in_from = False
 

--- a/tests/checks/test_cross_join_check.py
+++ b/tests/checks/test_cross_join_check.py
@@ -210,3 +210,21 @@ class TestCheckCrossJoin(object):
         with self.patch_schema(schema):
             stmt = sqlparse.parse(sql)[0]
             assert True == self.has_cross_join(stmt)
+
+    def test_with_cross_join_with_group_and_subquery(self):
+        tbl_a, tbl_b = Mock(), Mock()
+        tbl_a.primary_key.columns.keys.return_value = ['projectid', 'systemid']
+        tbl_b.primary_key.columns.keys.return_value = ['projectid', 'systemid']
+        schema = {
+            'project': tbl_a,
+        }
+        sql = (
+            "SELECT projectid, name FROM ("
+            "SELECT projectid FROM project"
+            ") as anon_1 "
+            "GROUP BY projectid, name "
+            "ORDER BY anon_1.projectid ASC"
+        )
+        with self.patch_schema(schema):
+            stmt = sqlparse.parse(sql)[0]
+            assert False == self.has_cross_join(stmt)


### PR DESCRIPTION
When a dervied query uses more than one group by column it should not be marked as a cross join. The GROUP keyword indicates exiting the from clause.