### PR TITLE
Update the way we fetch requirements, it wasn't resolving dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 readme = open('README.rst').read()
 
-requirements = map(str.strip, open('requirements.txt').readlines())
+requirements = open('./requirements.txt', 'r').readlines()
 
 VERSION = open('VERSION').read().strip()
 


### PR DESCRIPTION
The old way returned a map object, which wasn't iterated over properly in 3.6