### PR TITLE
Unpin setuptools to prevent version conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sqlparse==0.2.4
 memoized-property==1.0.3
-setuptools==38.5.0
+setuptools
 future


### PR DESCRIPTION
Unpin setuptools to prevent version conflicts when sqlcop is a dependency.

Currently pinning setuptools will cause version conflicts when sqlcop is used in a project that has setuptools at a different version. We should be as flexible as we can so projects can use us without running into conflicts.