### PR TITLE
setuptools is considered unsafe in a requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 sqlparse==0.2.4
 memoized-property==1.0.3
-setuptools
 future


### PR DESCRIPTION
setuptools should only be needed to build this package, not install it.

Having this in `requirements.txt` is like opening a bakery and telling your customers that in order to buy your bread, they need to have an oven.

see https://github.com/jazzband/pip-tools/issues/522