### PR TITLE
Update parse_file to use UTF-8 on UnicodeDecodeError

### DIFF
--- a/sqlcop/cli.py
+++ b/sqlcop/cli.py
@@ -7,7 +7,12 @@ from sqlcop.checks.order_by_count import OrderByCountCheck
 
 
 def parse_file(filename):
-    return open(filename, 'r').readlines()
+    try:
+        return open(filename, 'r').readlines()
+    except UnicodeDecodeError:
+        # It's unclear whether or not something still relies on the ascii encoding so I've only changed it to use utf-8
+        # on exception.
+        return open(filename, 'r', encoding="utf-8").readlines()
 
 
 CHECKS = (

--- a/sqlcop/cli.py
+++ b/sqlcop/cli.py
@@ -10,8 +10,8 @@ def parse_file(filename):
     try:
         return open(filename, 'r').readlines()
     except UnicodeDecodeError:
-        # It's unclear whether or not something still relies on the ascii encoding so I've only changed it to use utf-8
-        # on exception.
+        # It's unclear whether or not something still relies on the ascii
+        # encoding so I've only changed it to use utf-8 on exception.
         return open(filename, 'r', encoding="utf-8").readlines()
 
 


### PR DESCRIPTION
`open` defaults to the local preferred encoding in python3, not UTF-8. If file open fails due to UnicodeDecodeError, python most likely tried to open the file with ASCII. This will try again with the encoding set explicitly to UTF-8. 